### PR TITLE
Fix imports and rename PDGame.is_player_1_turn to PDGame.is_p1_turn

### DIFF
--- a/PDGame.py
+++ b/PDGame.py
@@ -2,7 +2,7 @@
 
 Copyright (c) 2021 Abdus Shaikh, Jason Wang, Samraj Aneja, Kevin Wang
 """
-import Player
+from Player import Player
 
 
 class PDGame:
@@ -14,20 +14,22 @@ class PDGame:
       - player1: player which goes first
       - player2: player which goes second
       - decisions: maps round number to (player1's decision, player2's decision)
-      - is_player_1_turn: True if player1 is making a decision, and False otherwise
+      - is_p1_turn: True if player1 is making a decision, and False otherwise
     """
     num_rounds: int
     curr_round: int
     player1: Player
     player2: Player
     decisions: dict[int, tuple[bool, bool]]
-    is_player_1_turn: bool
+    is_p1_turn: bool
 
     def __init__(self, num_rounds: int, player1: Player, player2: Player):
         self.num_rounds = num_rounds
+        self.curr_round = 1
         self.player1 = player1
         self.player2 = player2
         self.decisions = {}
+        self.is_p1_turn = True
 
     def run_game(self) -> None:
         """Run a game between two computer strategies.

--- a/Player.py
+++ b/Player.py
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Abdus Shaikh, Jason Wang, Samraj Aneja, Kevin Wang
 """
 import Strategy
-import PDGame
+from PDGame import PDGame
 
 
 class Player:
@@ -18,10 +18,10 @@ class Player:
       - player_num in {1, 2}
     """
     curr_points: int
-    strategy: Strategy
+    strategy: Strategy.Strategy
     player_num: int
 
-    def __init__(self, strategy: Strategy, player_num: int):
+    def __init__(self, strategy: Strategy.Strategy, player_num: int):
         self.curr_points = 0
         self.strategy = strategy
         self.player_num = player_num

--- a/Strategy.py
+++ b/Strategy.py
@@ -2,7 +2,7 @@
 
 Copyright (c) 2021 Abdus Shaikh, Jason Wang, Samraj Aneja, Kevin Wang
 """
-import PDGame
+from PDGame import PDGame
 import random
 
 


### PR DESCRIPTION
Dumb me thought that we didn't need to specify module names when importing. Whoops.

Also, rename a long variable to reduce finger strain.