### PR TITLE
Fix insidious bugs and remove print calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,6 +80,10 @@ def create_and_run_game(num_rounds: int, player1: Player, player2: Player) -> No
         player2.curr_points += round_results[1]
 
         game.decisions[game.curr_round] = (move1, move2)
+
+        if isinstance(player1.strategy, LearningStrategy):
+            player1.strategy.update_game_tree_after_round(game)
+
         game.curr_round += 1
 
     ai_vs_ai_summary_screen(game, player1, player2)

--- a/pd_game.py
+++ b/pd_game.py
@@ -62,8 +62,6 @@ class PDGame:
         """Returns the winner of this game. If a tie, returns 3."""
         player1_score = self.get_points_prev(player1_num)
         player2_score = self.get_points_prev(player2_num)
-        print(player1_score)
-        print(player2_score)
         if player1_score > player2_score:
             return 1
         elif player1_score < player2_score:

--- a/pd_strategy.py
+++ b/pd_strategy.py
@@ -118,16 +118,16 @@ class GrimStrategy(Strategy):
     """A strategy that cooperates until its opponent has betrayed once, and betrays
     the rest of the game.
     """
-    # Private Instance Attributes:
-    #   - _been_betrayed: True if this player has been betrayed before, False otherwise
-
-    _been_betrayed: bool
-
     def __init__(self) -> None:
         self.name = 'Grim Strategy'
         self.desc = 'Cooperates until its opponent has betrayed \n' \
                     ' once, and betrays the rest of the game.'
-        self._been_betrayed = False
+
+    def _been_betrayed(self, game: PDGame) -> bool:
+        """Return whether the opponent has betrayed this game or not.
+        """
+        return False in [decision[self.get_opponent_num(game)] for decision in
+                         game.decisions.values()]
 
     def make_move(self, game: PDGame) -> bool:
         """Cooperates until its opponent has betrayed once, and betrays the rest of the game.
@@ -140,15 +140,11 @@ class GrimStrategy(Strategy):
         # always cooperates on round 1 (required since we can't check prev decisions)
         if curr_round == 1:
             return True
-        elif self._been_betrayed:
+
+        if self._been_betrayed(game):
             return False
         else:
-            prev_move = self.get_opponent_prev_move(game)
-            if prev_move is False:
-                self._been_betrayed = True
-                return False
-            else:
-                return True
+            return True
 
             # Version without self.assgined_player
 


### PR DESCRIPTION
Properly updates the LearningStrategy's tree in create_and_run_game as well as removes various print calls. Also band-aid fixes GrimStrategy not updating its _been_betrayed attribute by removing the attribute and recalculating its next decision from the game state manually every round.